### PR TITLE
Manual classes loading

### DIFF
--- a/includes/core/class-um-account-tabs.php
+++ b/includes/core/class-um-account-tabs.php
@@ -55,6 +55,7 @@ class UM_Account_Tabs {
 	 */
 	public function account() {
 		if ( empty( UM()->classes['um_account_tabs_account'] ) ) {
+			require_once um_account_tabs_path . 'includes/core/class-account.php';
 			UM()->classes['um_account_tabs_account'] = new um_ext\um_account_tabs\core\Account();
 		}
 		return UM()->classes['um_account_tabs_account'];
@@ -66,6 +67,7 @@ class UM_Account_Tabs {
 	 */
 	public function admin() {
 		if ( empty( UM()->classes['um_account_tabs_admin'] ) ) {
+			require_once um_account_tabs_path . 'includes/admin/class-admin.php';
 			UM()->classes['um_account_tabs_admin'] = new um_ext\um_account_tabs\admin\Admin();
 		}
 		return UM()->classes['um_account_tabs_admin'];
@@ -77,6 +79,7 @@ class UM_Account_Tabs {
 	 */
 	public function common() {
 		if ( empty( UM()->classes['um_account_tabs_common'] ) ) {
+			require_once um_account_tabs_path . 'includes/core/class-common.php';
 			UM()->classes['um_account_tabs_common'] = new um_ext\um_account_tabs\core\Common();
 		}
 		return UM()->classes['um_account_tabs_common'];

--- a/um-account-tabs.php
+++ b/um-account-tabs.php
@@ -61,11 +61,11 @@ if ( ! function_exists( 'um_account_tabs_check_dependencies' ) ) {
 					UM()->set_class( 'Account_Tabs', true );
 				}
 			}
-			add_action( 'plugins_loaded', 'um_account_tabs_init', -10, 1 );
+			add_action( 'plugins_loaded', 'um_account_tabs_init', 4, 1 );
 		}
 	}
 }
-add_action( 'plugins_loaded', 'um_account_tabs_check_dependencies', -20 );
+add_action( 'plugins_loaded', 'um_account_tabs_check_dependencies', 2 );
 
 // Loads a plugin's translated strings.
 if ( ! function_exists( 'um_account_tabs_plugins_loaded' ) ) {
@@ -75,4 +75,4 @@ if ( ! function_exists( 'um_account_tabs_plugins_loaded' ) ) {
 		load_plugin_textdomain( um_account_tabs_textdomain, false, dirname( plugin_basename( __FILE__ ) ) . '/languages/' );
 	}
 }
-add_action( 'plugins_loaded', 'um_account_tabs_plugins_loaded', 0 );
+add_action( 'plugins_loaded', 'um_account_tabs_plugins_loaded', 6 );


### PR DESCRIPTION
PHP Fatal error occurs if classes are not loaded. The Ultimate Member code should load classes automatically but this does not work on some sites. So, now classes are loaded manually via the `require_once`.