### PR TITLE
handling null or when no tab loaded

### DIFF
--- a/includes/core/class-account.php
+++ b/includes/core/class-account.php
@@ -55,6 +55,7 @@ class Account {
 			);
 			$tabs = get_posts( $args );
 
+			$this->tabs = array();
 			foreach( $tabs as $tab ){
 				$this->tabs[ $tab->post_name ] = $tab;
 			}


### PR DESCRIPTION
- fixed PHP warning when there is no custom account tabs